### PR TITLE
Define the editable object interface and able to get the relationship.

### DIFF
--- a/Object.Undo.Tests/EditableObjectRelationships/BaseEditableObjectRelationshipTest.cs
+++ b/Object.Undo.Tests/EditableObjectRelationships/BaseEditableObjectRelationshipTest.cs
@@ -1,0 +1,29 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Object.Undo.Interfaces;
+using Object.Undo.Utils;
+
+namespace Object.Undo.Tests.EditableObjectRelationships;
+
+public class BaseEditableObjectRelationshipTest
+{
+    protected void AssertRelationShip(IEditableObject parent, IEditableObject child, string? relationshipString)
+    {
+        var relationship = EditableObjectRelationship.CreateRelationship(parent, child);
+
+        if (relationshipString == null)
+        {
+            Assert.IsNull(relationship);
+        }
+        else
+        {
+            // Test should be able to get the relationship.
+            Assert.AreEqual(relationshipString, relationship!.ToString());
+
+            // Test should be able to get the child object from the relationship.
+            var actual = EditableObjectRelationship.GetPropertyFromRelationShip(parent, relationship);
+            Assert.IsTrue(EditableObjectUtils.IsSameInstance(child, actual));
+        }
+    }
+}

--- a/Object.Undo.Tests/EditableObjectRelationships/EditableClassObjectRelationshipTest.cs
+++ b/Object.Undo.Tests/EditableObjectRelationships/EditableClassObjectRelationshipTest.cs
@@ -1,0 +1,192 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Object.Undo.Interfaces;
+using Object.Undo.Properties;
+
+namespace Object.Undo.Tests.EditableObjectRelationships;
+
+/// <summary>
+/// Test the <see cref="EditableObjectRelationship"/> in the class object type.
+/// </summary>
+public class EditableClassObjectRelationshipTest : BaseEditableObjectRelationshipTest
+{
+    [Test]
+    public void TestChildInProperty()
+    {
+        var child = new ChildClass();
+        var parent = new ParentClassWithChildProperty
+        {
+            Child1 = child
+        };
+        AssertRelationShip(parent, child, "[Child1]");
+    }
+
+    [Test]
+    public void TestChildInInterfaceProperty()
+    {
+        var child = new ChildClass();
+        var parent = new ParentClassWithChildProperty
+        {
+            Child2 = child
+        };
+        AssertRelationShip(parent, child, "[Child2]");
+    }
+
+    [Test]
+    public void TestChildInList()
+    {
+        var child = new ChildClass();
+        var parent = new ParentClassWithChildList
+        {
+            Children1 = new List<ChildClass>
+            {
+                new(),
+                child
+            }
+        };
+        AssertRelationShip(parent, child, "[Children1, 1]");
+    }
+
+    [Test]
+    public void TestChildInListInterface()
+    {
+        var child = new ChildClass();
+        var parent = new ParentClassWithChildList
+        {
+            Children2 = new List<IEditableObject>
+            {
+                new ChildClass(),
+                child
+            }
+        };
+        AssertRelationShip(parent, child, "[Children2, 1]");
+    }
+
+    [Test]
+    public void TestChildInDictionary()
+    {
+        var child = new ChildClass();
+            var parent = new ParentClassWithChildDictionary
+        {
+            Children1 = new Dictionary<string, ChildClass>
+            {
+                { "1", new ChildClass() },
+                { "2", child }
+            }
+        };
+        AssertRelationShip(parent, child, "[Children1, key:2]");
+    }
+
+    [Test]
+    public void TestChildInObjectKeyDictionary()
+    {
+        var child = new ChildClass();
+        var parent = new ParentClassWithChildDictionary
+        {
+            Children2 = new Dictionary<DictionaryClassKey, ChildClass>
+            {
+                { new DictionaryClassKey(), new ChildClass() },
+                { new DictionaryClassKey(), child }
+            }
+        };
+        AssertRelationShip(parent, child, "[Children2, key:Object.Undo.Tests.EditableObjectRelationships.EditableClassObjectRelationshipTest+DictionaryClassKey]");
+    }
+
+    [Test]
+    public void TestChildInDictionaryKey()
+    {
+        var child = new ChildClass();
+        var parent = new ParentClassWithChildDictionary
+        {
+            Children3 = new Dictionary<ChildClass, string>
+            {
+                { new ChildClass(), "1" },
+                { child, "2" }
+            }
+        };
+        AssertRelationShip(parent, child, "[Children3, value:2]");
+    }
+
+    [Test]
+    public void TestChildInDictionaryKey2()
+    {
+        var child = new ChildClass();
+        var parent = new ParentClassWithChildDictionary
+        {
+            Children4 = new Dictionary<ChildClass, ChildClass>
+            {
+                { new ChildClass(), new ChildClass() },
+                { child, new ChildClass() }
+            }
+        };
+        AssertRelationShip(parent, child, "[Children4, value:Object.Undo.Tests.EditableObjectRelationships.EditableClassObjectRelationshipTest+ChildClass]");
+    }
+
+    [Test]
+    public void TestWrongOrder()
+    {
+        var child = new ChildClass();
+        var parent = new ParentClassWithChildProperty
+        {
+            Child1 = child
+        };
+        AssertRelationShip(child, parent, null);
+    }
+
+    [Test]
+    public void TestChildIsNotInParent()
+    {
+        var child = new ChildClass();
+        var parent = new ParentClassWithChildProperty();
+        AssertRelationShip(child, parent, null);
+    }
+
+    private class ParentClassWithChildProperty : IEditableObject
+    {
+        [EditableProperty]
+        public ChildClass? Child1 { get; set; }
+
+        [EditableProperty]
+        public IEditableObject? Child2 { get; set; }
+
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    private class ParentClassWithChildList : IEditableObject
+    {
+        [EditableProperty]
+        public IList<ChildClass>? Children1 { get; set; }
+
+        [EditableProperty]
+        public IList<IEditableObject>? Children2 { get; set; }
+
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    private class ParentClassWithChildDictionary : IEditableObject
+    {
+        [EditableProperty]
+        public IDictionary<string, ChildClass>? Children1 { get; set; }
+
+        [EditableProperty]
+        public IDictionary<DictionaryClassKey, ChildClass>? Children2 { get; set; }
+
+        [EditableProperty]
+        public IDictionary<ChildClass, string>? Children3 { get; set; }
+
+        [EditableProperty]
+        public IDictionary<ChildClass, ChildClass>? Children4 { get; set; }
+
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    private class DictionaryClassKey
+    {
+    }
+
+    private class ChildClass : IEditableObject
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+}

--- a/Object.Undo.Tests/EditableObjectRelationships/EditableStructObjectRelationshipTest.cs
+++ b/Object.Undo.Tests/EditableObjectRelationships/EditableStructObjectRelationshipTest.cs
@@ -1,0 +1,236 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Object.Undo.Interfaces;
+using Object.Undo.Properties;
+
+namespace Object.Undo.Tests.EditableObjectRelationships;
+
+/// <summary>
+/// Test the <see cref="EditableObjectRelationship"/> in the struct object type.
+/// </summary>
+public class EditableStructObjectRelationshipTest : BaseEditableObjectRelationshipTest
+{
+    [Test]
+    public void TestChildInProperty()
+    {
+        var child = new ChildStruct();
+        var parent = new ParentStructWithChildProperty
+        {
+            Child1 = child
+        };
+        AssertRelationShip(parent, child, "[Child1]");
+    }
+
+    [Test]
+    public void TestChildInInterfaceProperty()
+    {
+        var child = new ChildStruct();
+        var parent = new ParentStructWithChildProperty
+        {
+            Child2 = child
+        };
+        AssertRelationShip(parent, child, "[Child2]");
+    }
+
+    [Test]
+    public void TestChildInList()
+    {
+        var child = new ChildStruct();
+        var parent = new ParentStructWithChildList
+        {
+            Children1 = new List<ChildStruct>
+            {
+                new(),
+                child
+            }
+        };
+        AssertRelationShip(parent, child, "[Children1, 1]");
+    }
+
+    [Test]
+    public void TestChildInListInterface()
+    {
+        var child = new ChildStruct();
+        var parent = new ParentStructWithChildList
+        {
+            Children2 = new List<IEditableObject>
+            {
+                new ChildStruct(),
+                child
+            }
+        };
+        AssertRelationShip(parent, child, "[Children2, 1]");
+    }
+
+    [Test]
+    public void TestChildInDictionary()
+    {
+        var child = new ChildStruct();
+            var parent = new ParentStructWithChildDictionary
+        {
+            Children1 = new Dictionary<string, ChildStruct>
+            {
+                { "1", new ChildStruct() },
+                { "2", child }
+            }
+        };
+        AssertRelationShip(parent, child, "[Children1, key:2]");
+    }
+
+    [Test]
+    public void TestChildInObjectKeyDictionary()
+    {
+        var child = new ChildStruct();
+        var parent = new ParentStructWithChildDictionary
+        {
+            Children2 = new Dictionary<DictionaryStructKey, ChildStruct>
+            {
+                { new DictionaryStructKey(), child }
+            }
+        };
+        AssertRelationShip(parent, child, "[Children2, key:Object.Undo.Tests.EditableObjectRelationships.EditableStructObjectRelationshipTest+DictionaryStructKey]");
+    }
+
+    [Test]
+    public void TestChildInDictionaryKey()
+    {
+        var child = new ChildStruct();
+        var parent = new ParentStructWithChildDictionary
+        {
+            Children3 = new Dictionary<ChildStruct, string>
+            {
+                { new ChildStruct(), "1" },
+                { child, "2" }
+            }
+        };
+        AssertRelationShip(parent, child, "[Children3, value:2]");
+    }
+
+    [Test]
+    public void TestChildInDictionaryKey2()
+    {
+        var child = new ChildStruct();
+        var parent = new ParentStructWithChildDictionary
+        {
+            Children4 = new Dictionary<ChildStruct, ChildStruct>
+            {
+                { new ChildStruct(), new ChildStruct() },
+                { child, new ChildStruct() }
+            }
+        };
+        AssertRelationShip(parent, child, "[Children4, value:Object.Undo.Tests.EditableObjectRelationships.EditableStructObjectRelationshipTest+ChildStruct]");
+    }
+
+    [Test]
+    [Ignore("will get the wrong key if the value is struct.")]
+    public void TestChildInDictionaryKey3()
+    {
+        var child = new ChildStruct();
+        var parent = new ParentStructWithChildDictionary
+        {
+            Children5 = new Dictionary<ChildStruct, DictionaryStructKey>
+            {
+                { new ChildStruct(), new DictionaryStructKey() },
+                { child, new DictionaryStructKey() }
+            }
+        };
+        AssertRelationShip(parent, child, "[Children4, value:Object.Undo.Tests.EditableObjectRelationships.EditableStructObjectRelationshipTest+ChildStruct]");
+    }
+
+    [Test]
+    public void TestWrongOrder()
+    {
+        var child = new ChildStruct();
+        var parent = new ParentStructWithChildProperty
+        {
+            Child1 = child
+        };
+        AssertRelationShip(child, parent, null);
+    }
+
+    [Test]
+    public void TestChildIsNotInParent()
+    {
+        var child = new ChildStruct();
+        var parent = new ParentStructWithChildProperty();
+        AssertRelationShip(child, parent, null);
+    }
+
+    private struct ParentStructWithChildProperty : IEditableObject
+    {
+        public ParentStructWithChildProperty()
+        {
+            Child1 = null;
+            Child2 = null;
+        }
+
+        [EditableProperty]
+        public ChildStruct? Child1 { get; set; }
+
+        [EditableProperty]
+        public IEditableObject? Child2 { get; set; }
+
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    private struct ParentStructWithChildList : IEditableObject
+    {
+        public ParentStructWithChildList()
+        {
+            Children1 = null;
+            Children2 = null;
+        }
+
+        [EditableProperty]
+        public IList<ChildStruct>? Children1 { get; set; }
+
+        [EditableProperty]
+        public IList<IEditableObject>? Children2 { get; set; }
+
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    private struct ParentStructWithChildDictionary : IEditableObject
+    {
+        public ParentStructWithChildDictionary()
+        {
+            Children1 = null;
+            Children2 = null;
+            Children3 = null;
+            Children4 = null;
+            Children5 = null;
+        }
+
+        [EditableProperty]
+        public IDictionary<string, ChildStruct>? Children1 { get; set; }
+
+
+        [EditableProperty]
+        public IDictionary<DictionaryStructKey, ChildStruct>? Children2 { get; set; }
+
+        [EditableProperty]
+        public IDictionary<ChildStruct, string>? Children3 { get; set; }
+
+        [EditableProperty]
+        public IDictionary<ChildStruct, ChildStruct>? Children4 { get; set; }
+
+        [EditableProperty]
+        public IDictionary<ChildStruct, DictionaryStructKey>? Children5 { get; set; }
+
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    private struct DictionaryStructKey
+    {
+    }
+
+    private struct ChildStruct : IEditableObject
+    {
+        public ChildStruct()
+        {
+        }
+
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+}

--- a/Object.Undo.Tests/Utils/EditableObjectUtilsTest.cs
+++ b/Object.Undo.Tests/Utils/EditableObjectUtilsTest.cs
@@ -1,0 +1,106 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Object.Undo.Interfaces;
+using Object.Undo.Utils;
+
+namespace Object.Undo.Tests.Utils;
+
+public class EditableObjectUtilsTest
+{
+    #region Class
+
+    [Test]
+    public void TestSameEditableClass()
+    {
+        var editableObject = new EditableClass();
+        Assert.IsTrue(EditableObjectUtils.IsSameInstance(editableObject, editableObject));
+    }
+
+    [Test]
+    public void TestDifferentEditableClass()
+    {
+        var editableObject1 = new EditableClass();
+        var editableObject2 = new EditableClass();
+        Assert.IsFalse(EditableObjectUtils.IsSameInstance(editableObject1, editableObject2));
+    }
+
+    [Test]
+    public void TestSameEditableClassWithWrongId()
+    {
+        var editableObject = new WrongEditableClass();
+        Assert.Throws<ArgumentException>(() => EditableObjectUtils.IsSameInstance(editableObject, editableObject));
+    }
+
+    [Test]
+    public void TestDifferentEditableClassWithWrongId()
+    {
+        var editableObject1 = new WrongEditableClass();
+        var editableObject2 = new WrongEditableClass();
+        Assert.Throws<ArgumentException>(() => EditableObjectUtils.IsSameInstance(editableObject1, editableObject2));
+    }
+
+    private class EditableClass : IEditableObject
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    private class WrongEditableClass : IEditableObject
+    {
+        public Guid Id { get; } = Guid.Empty;
+    }
+
+    #endregion
+
+    #region Struct
+
+    [Test]
+    public void TestSameEditableStruct()
+    {
+        var editableObject = new EditableStruct();
+        Assert.IsTrue(EditableObjectUtils.IsSameInstance(editableObject, editableObject));
+    }
+
+    [Test]
+    public void TestDifferentEditableStruct()
+    {
+        var editableObject1 = new EditableStruct();
+        var editableObject2 = new EditableStruct();
+        Assert.IsFalse(EditableObjectUtils.IsSameInstance(editableObject1, editableObject2));
+    }
+
+    [Test]
+    public void TestSameEditableStructWithWrongId()
+    {
+        var editableObject = new WrongEditableStruct();
+        Assert.Throws<ArgumentException>(() => EditableObjectUtils.IsSameInstance(editableObject, editableObject));
+    }
+
+    [Test]
+    public void TestDifferentEditableStructWithWrongId()
+    {
+        var editableObject1 = new WrongEditableStruct();
+        var editableObject2 = new WrongEditableStruct();
+        Assert.Throws<ArgumentException>(() => EditableObjectUtils.IsSameInstance(editableObject1, editableObject2));
+    }
+
+    private struct EditableStruct : IEditableObject
+    {
+        public EditableStruct()
+        {
+        }
+
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    private struct WrongEditableStruct : IEditableObject
+    {
+        public WrongEditableStruct()
+        {
+        }
+
+        public Guid Id { get; } = Guid.Empty;
+    }
+
+    #endregion
+}

--- a/Object.Undo/EditableObjectRelationship.cs
+++ b/Object.Undo/EditableObjectRelationship.cs
@@ -1,0 +1,264 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Object.Undo.Interfaces;
+using Object.Undo.Properties;
+using Object.Undo.Utils;
+
+namespace Object.Undo;
+
+public class EditableObjectRelationship
+{
+    private readonly IList<Layer> layers = new List<Layer>();
+
+    #region Get relationshipt
+
+    public static EditableObjectRelationship? CreateRelationship(IEditableObject parent, IEditableObject target)
+    {
+        var layers = findLayers(parent, target);
+        if (layers == null)
+            return null;
+
+        var relationship = new EditableObjectRelationship();
+        foreach (var layer in layers)
+        {
+            relationship.layers.Add(layer);
+        }
+        return relationship;
+    }
+
+    private static Stack<Layer>? findLayers(IEditableObject parent, IEditableObject target)
+    {
+        if (EditableObjectUtils.IsSameInstance(parent, target))
+            return new Stack<Layer>();
+
+        foreach (var propertyInfo in getEditableProperties(parent))
+        {
+            var propertyName = propertyInfo.Name;
+            var propertyValue = propertyInfo.GetValue(parent);
+
+            var childValue = propertyValue switch
+            {
+                IEditableObject editableObject => findLayerInProperty(propertyName, editableObject, target),
+                IList list => findLayerInListProperty(propertyName, list, target),
+                IDictionary dictionary => findLayerInDictionaryProperty(propertyName, dictionary, target),
+                null => null,
+                _ => throw new InvalidOperationException()
+            };
+
+            if (childValue != null)
+                return childValue;
+        }
+
+        return null;
+
+        static IEnumerable<PropertyInfo> getEditableProperties(object parent)
+            => parent.GetType().GetProperties().Where(x => Attribute.IsDefined(x,typeof(EditablePropertyAttribute)));
+    }
+
+    private static Stack<Layer>? findLayerInProperty(string propertyName, IEditableObject propertyValue, IEditableObject target)
+    {
+        var stack = findLayers(propertyValue, target);
+        stack?.Push(new PropertyLayer(propertyName));
+
+        return stack;
+    }
+
+    private static Stack<Layer>? findLayerInListProperty(string propertyName, IList propertyValue, IEditableObject target)
+    {
+        for(int i = 0; i < propertyValue.Count; i++)
+        {
+            if(propertyValue[i] is not IEditableObject editableObject)
+                continue;
+
+            var stack = findLayers(editableObject, target);
+            if (stack == null)
+                continue;
+
+            stack.Push(new ListLayer(propertyName, i));
+            return stack;
+        }
+
+        return null;
+    }
+
+    private static Stack<Layer>? findLayerInDictionaryProperty(string propertyName, IDictionary propertyValue, IEditableObject target)
+    {
+        // get value by key
+        foreach (var key in propertyValue.Keys)
+        {
+            if(propertyValue[key] is not IEditableObject editableObject)
+                continue;
+
+            var stack = findLayers(editableObject, target);
+            if (stack == null)
+                continue;
+
+            stack.Push(new DictionaryValueLayer(propertyName, key));
+            return stack;
+        }
+
+        // get key by value
+        foreach (var value in propertyValue.Values)
+        {
+            if (getKeyByValue(propertyValue, value) is not IEditableObject editableObject)
+                continue;
+
+            var stack = findLayers(editableObject, target);
+            if (stack == null)
+                continue;
+
+            stack.Push(new DictionaryKeyLayer(propertyName, value));
+            return stack;
+        }
+
+        return null;
+    }
+
+    #endregion
+
+    #region Apply relationship
+
+    public static TEditableObject GetPropertyFromRelationShip<TEditableObject>(IEditableObject parent, EditableObjectRelationship relationship)
+        where TEditableObject : IEditableObject
+    {
+        var value = GetPropertyFromRelationShip(parent, relationship);
+
+        if (value is not TEditableObject editableObject)
+            throw new InvalidCastException();
+
+        return editableObject;
+    }
+
+
+    public static IEditableObject GetPropertyFromRelationShip(IEditableObject parent, EditableObjectRelationship relationship)
+    {
+        return relationship.layers.Aggregate(parent, getValue);
+
+        static IEditableObject getValue(object parent, Layer layer)
+        {
+            var property = parent.GetType().GetProperty(layer.PropertyName);
+            if (property == null)
+                throw new NullReferenceException($"Property {layer.PropertyName} not found in {parent.GetType()}");
+
+            var propertyValue = property.GetValue(parent);
+            return getEditableObjectFromProperty(propertyValue, layer);
+        }
+    }
+
+    private static IEditableObject getEditableObjectFromProperty(object propertyValue, Layer layer)
+    {
+        var childValue = layer switch
+        {
+            PropertyLayer => propertyValue,
+            ListLayer listLayer => ((IList)propertyValue)[listLayer.Index],
+            DictionaryKeyLayer dictionaryLayer => getKeyByValue((IDictionary)propertyValue, dictionaryLayer.Value),
+            DictionaryValueLayer dictionaryLayer => ((IDictionary)propertyValue)[dictionaryLayer.Key],
+            _ => throw new InvalidOperationException()
+        };
+
+        if (childValue is not IEditableObject editableObject)
+            throw new InvalidCastException();
+
+        return editableObject;
+    }
+
+    #endregion
+
+    #region Utils
+
+    private static object getKeyByValue(IDictionary dictionary, object value)
+    {
+        foreach (var key in dictionary.Keys)
+        {
+            // Note that will get the wrong key if the value is struct.
+            if (dictionary[key].Equals(value))
+                return key;
+        }
+
+        throw new NullReferenceException($"Key not found in dictionary for value {value}");
+    }
+
+    #endregion
+
+    public override string ToString()
+    {
+        return string.Join(",", layers.Select(x => x.ToString()));
+    }
+
+    private abstract class Layer
+    {
+        public string PropertyName { get; }
+
+        protected Layer(string propertyName)
+        {
+            PropertyName = propertyName;
+        }
+    }
+
+    private class PropertyLayer : Layer
+    {
+        public PropertyLayer(string propertyName)
+            : base(propertyName)
+        {
+        }
+
+        public override string ToString()
+        {
+            return $"[{PropertyName}]";
+        }
+    }
+
+    private class ListLayer : Layer
+    {
+        public int Index { get; }
+
+        public ListLayer(string propertyName, int index)
+            : base(propertyName)
+        {
+            Index = index;
+        }
+
+        public override string ToString()
+        {
+            return $"[{PropertyName}, {Index}]";
+        }
+    }
+
+    private class DictionaryKeyLayer : Layer
+    {
+        public object Value { get; }
+
+        public DictionaryKeyLayer(string propertyName, object value)
+            : base(propertyName)
+        {
+            Value = value;
+        }
+
+        public override string ToString()
+        {
+            return $"[{PropertyName}, value:{Value}]";
+        }
+    }
+
+    private class DictionaryValueLayer : Layer
+    {
+        public object Key { get; }
+
+        public DictionaryValueLayer(string propertyName, object key)
+            : base(propertyName)
+        {
+            Key = key;
+        }
+
+        public override string ToString()
+        {
+            return $"[{PropertyName}, key:{Key}]";
+        }
+    }
+}

--- a/Object.Undo/Extensions/TypeExtension.cs
+++ b/Object.Undo/Extensions/TypeExtension.cs
@@ -1,0 +1,13 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+
+namespace Object.Undo.Extensions;
+
+public static class TypeExtension
+{
+    public static bool InheritInterface<T>(this Type type)
+        => type.GetInterfaces().Contains(typeof(T));
+}

--- a/Object.Undo/Interfaces/IEditableObject.cs
+++ b/Object.Undo/Interfaces/IEditableObject.cs
@@ -1,0 +1,15 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace Object.Undo.Interfaces;
+
+/// <summary>
+/// All editable object should implement this interface.
+/// For able to identify the object.
+/// </summary>
+public interface IEditableObject
+{
+    Guid Id { get; }
+}

--- a/Object.Undo/Properties/EditablePropertyAttribute.cs
+++ b/Object.Undo/Properties/EditablePropertyAttribute.cs
@@ -1,0 +1,18 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Object.Undo.Interfaces;
+
+namespace Object.Undo.Properties;
+
+/// <summary>
+/// Should add this attribute to the property that able to be edited.
+/// Means the property in the class can be undo/redo.
+/// Note that the class should add the <see cref="IEditableObject"/>
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+
+public class EditablePropertyAttribute: Attribute
+{
+}

--- a/Object.Undo/Utils/EditableObjectUtils.cs
+++ b/Object.Undo/Utils/EditableObjectUtils.cs
@@ -1,0 +1,20 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Object.Undo.Interfaces;
+
+namespace Object.Undo.Utils;
+
+public static class EditableObjectUtils
+{
+    public static bool IsSameInstance(IEditableObject obj1, IEditableObject obj2)
+    {
+        if (obj1.Id == Guid.Empty || obj2.Id == Guid.Empty)
+            throw new ArgumentException(
+                "The ID of the object is empty. Editable object must have the random Guid.");
+
+        // technically Guid will not duplicated, but it's better to check is the same instance.
+        return obj1.Equals(obj2) && obj1.Id == obj2.Id;
+    }
+}


### PR DESCRIPTION
What's done in this PR:
1. define the `IEditableObject` interface. All editable object(class and struct) should inherit this interface.
    - `Id` in the `IEditableObject` is for distinguish the struct. Can remove this property in this project if not want to support edit the property in the struct.
    - Implement the utils to check two `IEditableObject` is the same instance or not.
2. define the `EditableProperty` attribute for able to find the `IEditableObject` in the parent of `IEditableObject`
    - The benefit for adding this property is let developers easy to check which property has `IEditableObject`.
3. Implement the relationship class for able to find the relationship between two objects.