### PR TITLE
Rename the property name for better understanding.

### DIFF
--- a/Object.Undo.Tests/EditableObjectRelationships/EditableObjectInDictionaryTest.cs
+++ b/Object.Undo.Tests/EditableObjectRelationships/EditableObjectInDictionaryTest.cs
@@ -70,16 +70,16 @@ public class EditableObjectInDictionaryTest : BaseEditableObjectRelationshipTest
 
     private class ParentWithChildDictionary : IEditableObject
     {
-        [EditableProperty]
+        [ChildEditableObject]
         public IDictionary<string, Child>? Children1 { get; set; }
 
-        [EditableProperty]
+        [ChildEditableObject]
         public IDictionary<DictionaryKey, Child>? Children2 { get; set; }
 
-        [EditableProperty]
+        [ChildEditableObject]
         public IDictionary<Child, string>? Children3 { get; set; }
 
-        [EditableProperty]
+        [ChildEditableObject]
         public IDictionary<Child, Child>? Children4 { get; set; }
 
         public Guid Id { get; } = Guid.NewGuid();

--- a/Object.Undo.Tests/EditableObjectRelationships/EditableObjectInListTest.cs
+++ b/Object.Undo.Tests/EditableObjectRelationships/EditableObjectInListTest.cs
@@ -40,10 +40,10 @@ public class EditableObjectInListTest : BaseEditableObjectRelationshipTest
 
     private class ParentWithChildList : IEditableObject
     {
-        [EditableProperty]
+        [ChildEditableObject]
         public IList<Child>? Children1 { get; set; }
 
-        [EditableProperty]
+        [ChildEditableObject]
         public IList<IEditableObject>? Children2 { get; set; }
 
         public Guid Id { get; } = Guid.NewGuid();

--- a/Object.Undo.Tests/EditableObjectRelationships/EditableObjectInPropertyTest.cs
+++ b/Object.Undo.Tests/EditableObjectRelationships/EditableObjectInPropertyTest.cs
@@ -32,10 +32,10 @@ public class EditableObjectInPropertyTest : BaseEditableObjectRelationshipTest
 
     private class ParentWithChildProperty : IEditableObject
     {
-        [EditableProperty]
+        [ChildEditableObject]
         public Child? Child1 { get; set; }
 
-        [EditableProperty]
+        [ChildEditableObject]
         public IEditableObject? Child2 { get; set; }
 
         public Guid Id { get; } = Guid.NewGuid();

--- a/Object.Undo.Tests/EditableObjectRelationships/EditableObjectWithInvalidCaseTest.cs
+++ b/Object.Undo.Tests/EditableObjectRelationships/EditableObjectWithInvalidCaseTest.cs
@@ -32,7 +32,7 @@ public class EditableObjectWithInvalidCaseTest : BaseEditableObjectRelationshipT
 
     private class ParentWithChildProperty : IEditableObject
     {
-        [EditableProperty]
+        [ChildEditableObject]
         public Child? Child1 { get; set; }
 
         public Guid Id { get; } = Guid.NewGuid();

--- a/Object.Undo/EditableObjectRelationship.cs
+++ b/Object.Undo/EditableObjectRelationship.cs
@@ -58,7 +58,7 @@ public class EditableObjectRelationship
         return null;
 
         static IEnumerable<PropertyInfo> getEditableProperties(object parent)
-            => parent.GetType().GetProperties().Where(x => Attribute.IsDefined(x,typeof(EditablePropertyAttribute)));
+            => parent.GetType().GetProperties().Where(x => Attribute.IsDefined(x,typeof(ChildEditableObjectAttribute)));
     }
 
     private static Stack<Layer>? findLayerInProperty(string propertyName, IEditableObject propertyValue, IEditableObject target)

--- a/Object.Undo/Properties/ChildEditableObjectAttribute.cs
+++ b/Object.Undo/Properties/ChildEditableObjectAttribute.cs
@@ -7,12 +7,11 @@ using Object.Undo.Interfaces;
 namespace Object.Undo.Properties;
 
 /// <summary>
-/// Should add this attribute to the property that able to be edited.
-/// Means the property in the class can be undo/redo.
-/// Note that the class should add the <see cref="IEditableObject"/>
+/// Should add this attribute to the property that container the <see cref="IEditableObject"/>.
+/// Note that the parent class should inherit the <see cref="IEditableObject"/>
 /// </summary>
 [AttributeUsage(AttributeTargets.Property)]
 
-public class EditablePropertyAttribute: Attribute
+public class ChildEditableObjectAttribute: Attribute
 {
 }


### PR DESCRIPTION
`EditableProperty` -> `ChildEditableObject`.

This property should be used to mark all the properties that contains the child `EditableObject`.
Not the editable property(e.g. string property) in the parent `EditableObject`.